### PR TITLE
Use HTTPS for git.io requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## gitio [![GoDoc](https://godoc.org/github.com/xlab/gitio?status.svg)](https://godoc.org/github.com/xlab/gitio)
 
-This is a Go client for [git.io](http://git.io).
+This is a Go client for [git.io](https://git.io).
 
 Read more about git.io [here](https://github.com/blog/985-git-io-github-url-shortener).
 
@@ -14,11 +14,11 @@ Or grab a binary in the [Releases](https://github.com/xlab/gitio/releases) secti
 ```
 $ gitio -h
 Usage: gitio <long url>
-  -c, --code=""        A custom code for the short link, e.g. http://git.io/mycode
+  -c, --code=""        A custom code for the short link, e.g. https://git.io/mycode
   -f, --force=false    Try to shorten link even if the custom code has been used previously.
 
 $ gitio -c gitio.go https://github.com/xlab/gitio/blob/master/gitio.go
-http://git.io/gitio.go
+https://git.io/gitio.go
 ```
 
 ### License

--- a/cmd/gitio/main.go
+++ b/cmd/gitio/main.go
@@ -16,7 +16,7 @@ var (
 )
 
 func init() {
-	mflag.StringVar(&codeOpt, []string{"c", "-code"}, "", "A custom code for the short link, e.g. http://git.io/mycode")
+	mflag.StringVar(&codeOpt, []string{"c", "-code"}, "", "A custom code for the short link, e.g. https://git.io/mycode")
 	mflag.BoolVar(&forceOpt, []string{"f", "-force"}, false, "Try to shorten link even if the custom code has been used previously.")
 
 	mflag.Usage = func() {

--- a/gitio.go
+++ b/gitio.go
@@ -1,4 +1,4 @@
-// Package gitio is a client for http://git.io URL shortener.
+// Package gitio is a client for https://git.io URL shortener.
 package gitio
 
 import (
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	gitioPostAPI = "http://git.io/create"
-	gitioPutAPI  = "http://git.io"
-	gitioGetAPI  = "http://git.io"
+	gitioPostAPI = "https://git.io/create"
+	gitioPutAPI  = "https://git.io"
+	gitioGetAPI  = "https://git.io"
 )
 
-const gitioAPI = "http://git.io/create"
+const gitioAPI = "https://git.io/create"
 
 // Shorten returns a short version of an URL, or an error otherwise.
 // Please note that it's not guaranteed the code will be accepted by git.io,


### PR DESCRIPTION
The git.io service has moved to https://git.io instead of http://git.io.
This updates the references to the URL through gitio to use https://.

This fixes the issue with the 301 redirect error when using gitio.

Fixes #2.
